### PR TITLE
change name in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "final_project",
+    "name": "deliveboo-backend",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {


### PR DESCRIPTION
Il file package.json aveva nome final_project, io quando ho clonato la repo, ho dato nome alla mia cartella in locale "deliveboo-backend" e questo ha fatto in modo di far variare anche il name del file package.json, trovandolo più corretto, lo pusho